### PR TITLE
fix: global place search results now appear in "Other results" section

### DIFF
--- a/src/components/search/SearchPanel.tsx
+++ b/src/components/search/SearchPanel.tsx
@@ -138,15 +138,18 @@ export function SearchPanel({ query, mode }: SearchPanelProps) {
   // section (we don't reorder across sections — "in this area" stays
   // a separate group).
   const allAccumulated = useMemo(
-    () => Array.from(accumulatedRef.current.values()),
-    // accumulatedRef is mutated imperatively above; re-read whenever
-    // the upstream queries deliver fresh results.
+    () => {
+      // Merge nearby (bounded) + global so the enrichment pipeline
+      // covers both — without this, enrichedGlobal was always empty.
+      const combined = new Map(accumulatedRef.current);
+      for (const r of globalResultsRaw) {
+        const key = `${r.osm_type}:${r.osm_id}`;
+        if (!combined.has(key)) combined.set(key, r);
+      }
+      return Array.from(combined.values());
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      latestNearby,
-      globalResultsRaw,
-      accumulatedRef.current.size,
-    ],
+    [latestNearby, globalResultsRaw, accumulatedRef.current.size],
   );
   const enrichedAll = useEnrichedSearchResults(allAccumulated);
   const enrichedByKey = useMemo(() => {

--- a/src/lib/api/nominatim.ts
+++ b/src/lib/api/nominatim.ts
@@ -159,7 +159,7 @@ export async function searchPlaces(
   const url = new URL(`${NOMINATIM_BASE}/search`, window.location.origin);
   url.searchParams.set("q", query);
   url.searchParams.set("format", "json");
-  url.searchParams.set("limit", "8");
+  url.searchParams.set("limit", "20");
   url.searchParams.set("dedupe", "1");
   url.searchParams.set("addressdetails", "0");
 


### PR DESCRIPTION
Fixes #4

The "Other results" section in the place search panel was always empty because global Nominatim results were never included in the enrichment pipeline.

**Root cause:** `allAccumulated` only contained nearby (bounded) results, so `enrichedByKey` had no entries for global places. Every lookup in `enrichedGlobal` returned `undefined` and was filtered out.

**Changes:**
- `SearchPanel.tsx`: merge nearby + global results into `allAccumulated` so the enrichment hook covers both; map overlay also now shows global markers
- `nominatim.ts`: global search limit 8 → 20 so more results survive dedup against nearby hits

Generated with [Claude Code](https://claude.ai/code)