### PR TITLE
feat: sequences as a first-class feature (markers, detail, discovery, upload polish)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -29,13 +29,33 @@ Tracked items deferred from API/UX audits. Cross-repo items note which repo owns
 - ~~**Tag filter on viewport** (app + plugin)~~ — **already covered by global search**.
   `<SearchBar />` / `<SearchPanel />` already do tag-driven map filtering: typing a tag hits `/v0/mapky/search/tags?q=`, the search panel calls `useAutoFocusLayer(null, { hide: true })` to clear the regular Places layer, and `<SearchResultsOverlay />` renders the matching places as the same teardrop balloons. No separate viewport-level `?tags=` predicate needed.
 
+## Geocaptures + sequences
+
+- ~~**Sequence display on map** (plugin + app)~~ — **shipped** (mapky-nexus-plugin#3 + mapky-app#16).
+  `<SequenceMarkersLayer />` renders one violet pill marker per sequence at the bbox centroid. Polyline lifted 0.35→0.55. Backend: `/v0/mapky/sequences/viewport` (bbox-overlap query) + `/v0/mapky/sequences/{a}/{id}/full` composite.
+
+- ~~**Sequence detail + tag/post on sequences as a whole** (plugin + app)~~ — **shipped**.
+  `/sequence/$author/$id` route + `<SequenceDetailPanel />` (header, description, capture grid, tags, reply thread). Composite cache → 1 round-trip per panel open. `<SequenceTags />` reuses TagStrip's composite-cache callbacks. `ResourceDiscussion` already supported `resourceType: "sequences"` — backend was ready, just wired the UI.
+
+- ~~**Sequence discovery sidebar + search navigation** (app)~~ — **shipped**.
+  `/sequences` route with Mine + In-this-area tabs. IconRail entry. SearchPanel: sequence rows clickable + post-parent resolution.
+
+- ~~**Capture upload UX polish** (app)~~ — **shipped**.
+  Drag-drop on empty PickStep zone. EXIF GPS-coverage banner when picked set has a mix.
+
+- **Capture markers in `<SearchResultsOverlay />`** (app, deferred)
+  Captures and sequences don't currently render as map balloons during search (only places, routes, collections, reviews). Search list nav covers most of the UX, but adding map balloons would close the gap. Low-priority polish.
+
+- **Sequence rename / delete** (app)
+  Owner-only edit affordances on the SequenceDetailPanel. Deferred.
+
+- **Reorder captures within a published sequence** (app + plugin)
+  Currently `sequence_index` is fixed at upload. UI for re-sorting members is a larger refactor — deferred.
+
 ## Plugin endpoints — defer cleanup
 
 - **Incidents endpoints** (`/incidents/viewport`, `/incidents/{author}/{id}`, `/incidents/user/{id}`)
   Currently unused by the frontend. Per user direction, leave defined and improve later. Don't delete.
-
-- **Sequences endpoints** (`/sequences/{a}/{s}`, `/sequences/{a}/{s}/tags`, `/sequences/user/{id}`)
-  `/sequences/{a}/{s}/captures` and the new `/sequences/captures/by_ids` are consumed; the others stay defined for future use.
 
 - **BTC endpoints** (`/btc/viewport`, `/btc/status`)
   `/btc/viewport` is the BTC overlay layer's data source. `/btc/status` exposes BTCMap sync state — still unused but cheap to keep.

--- a/src/components/capture/CaptureCard.tsx
+++ b/src/components/capture/CaptureCard.tsx
@@ -1,0 +1,157 @@
+import { Link } from "@tanstack/react-router";
+import {
+  Camera,
+  Image as ImageIcon,
+  Video,
+  Mic,
+  Box,
+  CircleDot,
+} from "lucide-react";
+import { resolveFileUrl } from "@/lib/api/user";
+import { useMapStore } from "@/stores/map-store";
+import { CreatorBadge } from "@/components/discover/CreatorBadge";
+import type {
+  GeoCaptureDetails,
+  GeoCaptureKind,
+  PostTagDetails,
+} from "@/types/mapky";
+
+interface CaptureCardProps {
+  capture: GeoCaptureDetails;
+  /** Tags to surface on the card (top 2 rendered as chips). */
+  tags?: PostTagDetails[];
+  /** When false, suppress the per-card creator badge. Useful when
+   *  the card is rendered inside a single-author context (e.g. a
+   *  sequence detail page) where the author's already named once. */
+  showCreator?: boolean;
+  /** Skip the flyTo on click (callers like SequenceDetailPanel
+   *  manage their own map focus). */
+  flyToOnClick?: boolean;
+}
+
+/**
+ * Square thumbnail card for a single geo-capture. Click → opens the
+ * capture detail panel via TanStack Router. Used by CaptureList's
+ * grid and the SequenceDetailPanel's member gallery.
+ */
+export function CaptureCard({
+  capture,
+  tags = [],
+  showCreator = true,
+  flyToOnClick = true,
+}: CaptureCardProps) {
+  const map = useMapStore((s) => s.map);
+  const [authorId, captureId] = splitCompound(capture.id, capture.author_id);
+  const thumb = thumbnailUrl(capture);
+  const Icon = kindIcon(capture.kind);
+  const topTags = tags.slice(0, 2);
+
+  return (
+    <Link
+      to="/capture/$authorId/$captureId"
+      params={{ authorId, captureId }}
+      onClick={() => {
+        if (flyToOnClick && map) {
+          map.flyTo({
+            center: [capture.lon, capture.lat],
+            zoom: 17,
+            duration: 800,
+          });
+        }
+      }}
+      className="group relative aspect-square overflow-hidden rounded-md border border-border bg-surface transition-colors hover:border-accent"
+    >
+      {thumb ? (
+        <img
+          src={thumb}
+          alt={capture.caption ?? KIND_LABELS[capture.kind]}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted">
+          <Icon className="h-8 w-8" />
+        </div>
+      )}
+      <span className="pointer-events-none absolute left-1 top-1 flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[10px] font-medium text-foreground shadow-sm backdrop-blur">
+        <Icon className="h-3 w-3" />
+        {KIND_LABELS[capture.kind]}
+      </span>
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-0.5 bg-gradient-to-t from-black/80 to-transparent px-1.5 py-1">
+        {capture.caption && (
+          <span className="truncate text-[10px] text-white">
+            {capture.caption}
+          </span>
+        )}
+        {topTags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {topTags.map((t) => (
+              <span
+                key={t.label}
+                className="rounded-full bg-white/15 px-1.5 py-0.5 text-[10px] text-white"
+              >
+                {t.label}
+              </span>
+            ))}
+          </div>
+        )}
+        {showCreator && (
+          <CreatorBadge
+            authorId={authorId}
+            showName={false}
+            className="self-end"
+          />
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export function splitCompound(
+  id: string,
+  authorId: string,
+): [string, string] {
+  // GeoCaptureDetails.id is "author:capture"; fall back to author_id
+  // if the indexer ever returns just the bare capture id.
+  const idx = id.indexOf(":");
+  if (idx < 0) return [authorId, id];
+  return [id.slice(0, idx), id.slice(idx + 1)];
+}
+
+export function thumbnailUrl(c: GeoCaptureDetails): string | null {
+  // Audio / 3D / point-cloud have no still preview; show the icon
+  // fallback instead.
+  if (c.kind === "audio" || c.kind === "model3d" || c.kind === "point_cloud") {
+    return null;
+  }
+  return resolveFileUrl(c.file_uri);
+}
+
+export function kindIcon(kind: GeoCaptureKind) {
+  switch (kind) {
+    case "video":
+    case "video360":
+      return Video;
+    case "audio":
+      return Mic;
+    case "model3d":
+      return Box;
+    case "point_cloud":
+      return CircleDot;
+    case "panorama":
+      return Camera;
+    default:
+      return ImageIcon;
+  }
+}
+
+export const KIND_LABELS: Record<GeoCaptureKind, string> = {
+  photo: "Photo",
+  panorama: "360°",
+  video: "Video",
+  video360: "360° Video",
+  model3d: "3D",
+  point_cloud: "Point Cloud",
+  audio: "Audio",
+  other: "Other",
+};

--- a/src/components/capture/CaptureList.tsx
+++ b/src/components/capture/CaptureList.tsx
@@ -1,16 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { useQueries } from "@tanstack/react-query";
 import { Route as CapturesRoute } from "@/routes/captures";
-import {
-  Camera,
-  Loader2,
-  Image as ImageIcon,
-  Video,
-  Mic,
-  Box,
-  CircleDot,
-} from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useAuth } from "@/components/auth/AuthProvider";
 import {
   useUserGeoCaptures,
@@ -24,8 +16,6 @@ import {
   pointsToBounds,
   useFilterViewport,
 } from "@/hooks/use-filter-viewport";
-import { resolveFileUrl } from "@/lib/api/user";
-import { useMapStore } from "@/stores/map-store";
 import { useUiStore } from "@/stores/ui-store";
 import { fetchGeoCaptureTags } from "@/lib/api/mapky";
 import { DiscoverSidebar, type DiscoverTab } from "@/components/discover/DiscoverSidebar";
@@ -34,9 +24,12 @@ import {
   DiscoverFilter,
   type CategoryOption,
 } from "@/components/discover/Filter";
-import { CreatorBadge } from "@/components/discover/CreatorBadge";
+import {
+  CaptureCard,
+  KIND_LABELS,
+  splitCompound,
+} from "./CaptureCard";
 import type {
-  GeoCaptureDetails,
   GeoCaptureKind,
   PostTagDetails,
 } from "@/types/mapky";
@@ -249,119 +242,3 @@ export function CaptureList() {
   );
 }
 
-function CaptureCard({
-  capture,
-  tags = [],
-}: {
-  capture: GeoCaptureDetails;
-  tags?: PostTagDetails[];
-}) {
-  const map = useMapStore((s) => s.map);
-  const [authorId, captureId] = splitCompound(capture.id, capture.author_id);
-  const thumb = thumbnailUrl(capture);
-  const Icon = kindIcon(capture.kind);
-  const topTags = tags.slice(0, 2);
-
-  return (
-    <Link
-      to="/capture/$authorId/$captureId"
-      params={{ authorId, captureId }}
-      onClick={() => {
-        if (map) {
-          map.flyTo({
-            center: [capture.lon, capture.lat],
-            zoom: 17,
-            duration: 800,
-          });
-        }
-      }}
-      className="group relative aspect-square overflow-hidden rounded-md border border-border bg-surface transition-colors hover:border-accent"
-    >
-      {thumb ? (
-        <img
-          src={thumb}
-          alt={capture.caption ?? KIND_LABELS[capture.kind]}
-          className="h-full w-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <div className="flex h-full w-full items-center justify-center text-muted">
-          <Icon className="h-8 w-8" />
-        </div>
-      )}
-      <span className="pointer-events-none absolute left-1 top-1 flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[10px] font-medium text-foreground shadow-sm backdrop-blur">
-        <Icon className="h-3 w-3" />
-        {KIND_LABELS[capture.kind]}
-      </span>
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-0.5 bg-gradient-to-t from-black/80 to-transparent px-1.5 py-1">
-        {capture.caption && (
-          <span className="truncate text-[10px] text-white">
-            {capture.caption}
-          </span>
-        )}
-        {topTags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {topTags.map((t) => (
-              <span
-                key={t.label}
-                className="rounded-full bg-white/15 px-1.5 py-0.5 text-[10px] text-white"
-              >
-                {t.label}
-              </span>
-            ))}
-          </div>
-        )}
-        <CreatorBadge
-          authorId={authorId}
-          showName={false}
-          className="self-end"
-        />
-      </div>
-    </Link>
-  );
-}
-
-function splitCompound(id: string, authorId: string): [string, string] {
-  // GeoCaptureDetails.id is "author:capture"; fall back to author_id if
-  // the indexer ever returns just the bare capture id.
-  const idx = id.indexOf(":");
-  if (idx < 0) return [authorId, id];
-  return [id.slice(0, idx), id.slice(idx + 1)];
-}
-
-function thumbnailUrl(c: GeoCaptureDetails): string | null {
-  // Audio/3D/point-cloud have no still preview; show the icon instead.
-  if (c.kind === "audio" || c.kind === "model3d" || c.kind === "point_cloud") {
-    return null;
-  }
-  return resolveFileUrl(c.file_uri);
-}
-
-function kindIcon(kind: GeoCaptureKind) {
-  switch (kind) {
-    case "video":
-    case "video360":
-      return Video;
-    case "audio":
-      return Mic;
-    case "model3d":
-      return Box;
-    case "point_cloud":
-      return CircleDot;
-    case "panorama":
-      return Camera;
-    default:
-      return ImageIcon;
-  }
-}
-
-const KIND_LABELS: Record<GeoCaptureKind, string> = {
-  photo: "Photo",
-  panorama: "360°",
-  video: "Video",
-  video360: "360° Video",
-  model3d: "3D",
-  point_cloud: "Point Cloud",
-  audio: "Audio",
-  other: "Other",
-};

--- a/src/components/capture/SequenceDetailPanel.tsx
+++ b/src/components/capture/SequenceDetailPanel.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2, Calendar, MapPin, Camera, User } from "lucide-react";
+import { DiscoverSidebar } from "@/components/discover/DiscoverSidebar";
+import { UserAvatar } from "@/components/shared/UserAvatar";
+import { ResourceDiscussion } from "@/components/posts/ResourceDiscussion";
+import { CaptureCard, KIND_LABELS } from "./CaptureCard";
+import { SequenceTags } from "./SequenceTags";
+import {
+  useSequenceFullDetail,
+  useSequenceFullCaptures,
+  useUserProfile,
+} from "@/lib/api/hooks";
+import { useEnsureIngested } from "@/lib/nexus/use-ensure-ingested";
+import { useAutoFocusLayer } from "@/hooks/use-auto-focus-layer";
+import { useUiStore } from "@/stores/ui-store";
+import { useMapStore } from "@/stores/map-store";
+import { truncatePublicKey } from "@/lib/api/user";
+import type { PostTagDetails } from "@/types/mapky";
+
+interface SequenceDetailPanelProps {
+  authorId: string;
+  sequenceId: string;
+}
+
+/**
+ * Sequence detail surface — header (name, kind, author, time range),
+ * description, member captures grid, tags, discussion thread. Reads
+ * off a single composite-cache slice (`/sequences/{a}/{s}/full`) so
+ * opening fires ONE round-trip total.
+ *
+ * Sequence members are pinned via `setPinnedCaptures` so the map's
+ * capture layer keeps them visible regardless of the current bbox —
+ * the user can pan around the sequence's footprint without losing
+ * the dots that connect it.
+ */
+export function SequenceDetailPanel({
+  authorId,
+  sequenceId,
+}: SequenceDetailPanelProps) {
+  const navigate = useNavigate();
+  const { data: detail, isLoading, error } = useSequenceFullDetail(
+    authorId,
+    sequenceId,
+  );
+  const { data: captures = [] } = useSequenceFullCaptures(authorId, sequenceId);
+  useEnsureIngested(authorId);
+  const { data: authorProfile } = useUserProfile(authorId);
+  const authorName =
+    authorProfile?.name?.trim() || truncatePublicKey(authorId);
+
+  // Hide the place layer while a sequence is open; keep captures
+  // layer enabled (the sequence's members ARE captures and we want
+  // them dimmed-but-visible).
+  useAutoFocusLayer("places", { hide: true });
+
+  // Pin members so they stay drawn even when the user pans away
+  // from the sequence's bbox.
+  const setPinnedCaptures = useUiStore((s) => s.setPinnedCaptures);
+  useEffect(() => {
+    if (captures.length === 0) {
+      setPinnedCaptures(null);
+      return;
+    }
+    setPinnedCaptures(captures);
+    return () => setPinnedCaptures(null);
+  }, [captures, setPinnedCaptures]);
+
+  // FlyTo the sequence centroid on mount so the map shows the
+  // footprint without the user panning manually.
+  const map = useMapStore((s) => s.map);
+  useEffect(() => {
+    if (!map || !detail) return;
+    if (
+      detail.min_lat == null ||
+      detail.max_lat == null ||
+      detail.min_lon == null ||
+      detail.max_lon == null
+    ) {
+      return;
+    }
+    map.fitBounds(
+      [
+        [detail.min_lon, detail.min_lat],
+        [detail.max_lon, detail.max_lat],
+      ],
+      { padding: 80, duration: 700, maxZoom: 15 },
+    );
+  }, [map, detail]);
+
+  const close = () => navigate({ to: "/" });
+
+  if (isLoading) {
+    return (
+      <DiscoverSidebar
+        title="Sequence"
+        onClose={close}
+      >
+        <div className="flex items-center gap-2 py-4 text-xs text-muted">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading…
+        </div>
+      </DiscoverSidebar>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <DiscoverSidebar title="Sequence" onClose={close}>
+        <p className="py-4 text-xs text-red-500">
+          {(error as Error | undefined)?.message ?? "Sequence not found"}
+        </p>
+      </DiscoverSidebar>
+    );
+  }
+
+  return (
+    <DiscoverSidebar
+      title={detail.name?.trim() || "Sequence"}
+      onClose={close}
+    >
+      <div className="space-y-4">
+        <Header
+          authorId={authorId}
+          authorName={authorName}
+          kind={detail.kind}
+          captureCount={detail.capture_count}
+          capturedAtStart={detail.captured_at_start}
+          capturedAtEnd={detail.captured_at_end}
+          device={detail.device}
+        />
+
+        {detail.description && (
+          <p className="whitespace-pre-wrap text-sm text-foreground">
+            {detail.description}
+          </p>
+        )}
+
+        <SequenceTags authorId={authorId} sequenceId={sequenceId} />
+
+        <CaptureGrid captures={captures} />
+
+        <div className="border-t border-border pt-4">
+          <ResourceDiscussion
+            resourceType="sequences"
+            authorId={authorId}
+            resourceId={sequenceId}
+          />
+        </div>
+      </div>
+    </DiscoverSidebar>
+  );
+}
+
+function Header({
+  authorId,
+  authorName,
+  kind,
+  captureCount,
+  capturedAtStart,
+  capturedAtEnd,
+  device,
+}: {
+  authorId: string;
+  authorName: string;
+  kind: string;
+  captureCount: number;
+  capturedAtStart: number;
+  capturedAtEnd: number;
+  device: string | null;
+}) {
+  const timeRange = useMemo(() => {
+    return formatTimeRange(capturedAtStart, capturedAtEnd);
+  }, [capturedAtStart, capturedAtEnd]);
+  const kindLabel = KIND_LABELS[kind as keyof typeof KIND_LABELS] ?? kind;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <UserAvatar userId={authorId} size={6} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1 text-xs text-muted">
+            <User className="h-3 w-3" aria-hidden />
+            <span className="truncate">{authorName}</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted">
+            <span className="inline-flex items-center gap-1">
+              <Camera className="h-3 w-3" aria-hidden />
+              {captureCount} {kindLabel.toLowerCase()}
+              {captureCount === 1 ? "" : "s"}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Calendar className="h-3 w-3" aria-hidden />
+              {timeRange}
+            </span>
+            {device && (
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3 w-3" aria-hidden />
+                {device}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CaptureGrid({
+  captures,
+}: {
+  captures: import("@/types/mapky").GeoCaptureDetails[];
+}) {
+  if (captures.length === 0) {
+    return (
+      <p className="text-xs text-muted">
+        This sequence has no captures yet.
+      </p>
+    );
+  }
+  return (
+    <div>
+      <h4 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted">
+        Captures
+      </h4>
+      <div className="grid grid-cols-3 gap-1">
+        {captures.map((c) => (
+          <CaptureCard
+            key={c.id}
+            capture={c}
+            tags={(c.tags ?? []) as PostTagDetails[]}
+            showCreator={false}
+            flyToOnClick={false}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatTimeRange(startMicros: number, endMicros: number): string {
+  // Indexer stores microseconds since epoch. Render as a single
+  // date when start/end share the day, otherwise "Mar 5 – Mar 7".
+  const start = new Date(Math.floor(startMicros / 1000));
+  const end = new Date(Math.floor(endMicros / 1000));
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  const fmt = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      start.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+  });
+  if (sameDay) return fmt.format(start);
+  return `${fmt.format(start)} – ${fmt.format(end)}`;
+}

--- a/src/components/capture/SequenceList.tsx
+++ b/src/components/capture/SequenceList.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Loader2, Film } from "lucide-react";
+import { Route as SequencesRoute } from "@/routes/sequences";
+import { useAuth } from "@/components/auth/AuthProvider";
+import {
+  useUserSequences,
+  useViewportSequences,
+} from "@/lib/api/hooks";
+import { useViewportBounds } from "@/hooks/use-viewport-bounds";
+import { useFrozenWhile } from "@/hooks/use-frozen-while";
+import { useAutoFocusLayer } from "@/hooks/use-auto-focus-layer";
+import {
+  pointsToBounds,
+  useFilterViewport,
+} from "@/hooks/use-filter-viewport";
+import { resolveFileUrl } from "@/lib/api/user";
+import { DiscoverSidebar, type DiscoverTab } from "@/components/discover/DiscoverSidebar";
+import { DiscoverFilter } from "@/components/discover/Filter";
+import { CreatorBadge } from "@/components/discover/CreatorBadge";
+import { KIND_LABELS } from "./CaptureCard";
+import type { SequenceDetails, SequenceViewportItem } from "@/types/mapky";
+
+type Tab = "mine" | "viewport";
+
+/**
+ * Sequences discover sidebar — Mine / In this area feed of geo-capture
+ * sequences. Mirrors `<CaptureList />` in shape and bbox-freeze
+ * behavior, with a name-only client filter (sequence tag density is
+ * low; richer filtering can come later if it's actually needed).
+ */
+export function SequenceList() {
+  const navigate = useNavigate();
+  const search = SequencesRoute.useSearch();
+  const { publicKey } = useAuth();
+
+  const tab: Tab = search.tab ?? (publicKey ? "mine" : "viewport");
+  const setTab = (next: Tab) => {
+    navigate({ to: "/sequences", search: { tab: next }, replace: true });
+  };
+
+  const [filter, setFilter] = useState("");
+  const filterActive = filter.trim().length > 0;
+
+  const liveBbox = useViewportBounds(tab === "viewport");
+  const bbox = useFrozenWhile(liveBbox, filterActive);
+
+  const userSequences = useUserSequences(tab === "mine" ? publicKey : null);
+  const viewport = useViewportSequences(tab === "viewport" ? bbox : null);
+
+  // Both branches return a list of objects shaped like
+  // SequenceDetails (the viewport variant adds an extra cover_uri).
+  // Cast to a union and let downstream code read shared fields.
+  const allSequences: ReadonlyArray<SequenceDetails | SequenceViewportItem> =
+    tab === "mine"
+      ? userSequences.data ?? []
+      : viewport.data ?? [];
+
+  const list = tab === "mine" ? userSequences : viewport;
+
+  const tabs: DiscoverTab[] = useMemo(() => {
+    const out: DiscoverTab[] = [];
+    if (publicKey) out.push({ id: "mine", label: "Mine" });
+    out.push({ id: "viewport", label: "In this area" });
+    return out;
+  }, [publicKey]);
+
+  const close = () => navigate({ to: "/" });
+
+  // Browsing sequences → fade places so the focused layer pops.
+  // Active filter → hide places entirely (full-focus mode).
+  useAutoFocusLayer("places", { hide: filterActive });
+
+  const filtered = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return [...allSequences];
+    return allSequences.filter((s) => {
+      const haystack = [s.name ?? "", s.description ?? "", s.device ?? ""]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [allSequences, filter]);
+
+  // Fit map to filtered sequences' centroids when filtering.
+  useFilterViewport({
+    active: filterActive,
+    bounds: pointsToBounds(
+      filtered
+        .filter((s) => s.min_lat != null && s.min_lon != null)
+        .map((s) => ({
+          lat: ((s.min_lat ?? 0) + (s.max_lat ?? 0)) / 2,
+          lon: ((s.min_lon ?? 0) + (s.max_lon ?? 0)) / 2,
+        })),
+    ),
+  });
+
+  return (
+    <DiscoverSidebar
+      title="Sequences"
+      onClose={close}
+      tabs={tabs}
+      activeTab={tab}
+      onTabChange={(t) => setTab(t as Tab)}
+    >
+      <DiscoverFilter
+        value={filter}
+        onChange={setFilter}
+        placeholder="Filter by name…"
+        activeTags={[]}
+        onRemoveTag={() => {}}
+        suggestedTags={[]}
+        onAddTag={() => {}}
+        tagMode="all"
+        onTagModeChange={() => {}}
+      />
+
+      {list.isLoading && (
+        <p className="flex items-center gap-2 text-xs text-muted">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading…
+        </p>
+      )}
+      {!list.isLoading && filtered.length === 0 && (
+        <p className="text-xs text-muted">
+          {tab === "mine"
+            ? "You haven't published any sequences yet."
+            : "No sequences in this area."}
+        </p>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        {filtered.map((s) => (
+          <SequenceCard key={s.id} sequence={s} />
+        ))}
+      </div>
+    </DiscoverSidebar>
+  );
+}
+
+function SequenceCard({
+  sequence,
+}: {
+  sequence: SequenceDetails | SequenceViewportItem;
+}) {
+  const [authorId, sequenceId] = splitCompound(sequence.id, sequence.author_id);
+  // viewport items carry a cover_uri; user-list items don't (yet).
+  const coverUri = "cover_uri" in sequence ? sequence.cover_uri : null;
+  const coverUrl = coverUri ? resolveFileUrl(coverUri) : null;
+  const kindLabel =
+    KIND_LABELS[sequence.kind as keyof typeof KIND_LABELS] ?? sequence.kind;
+  return (
+    <Link
+      to="/sequence/$authorId/$sequenceId"
+      params={{ authorId, sequenceId }}
+      className="group relative aspect-square overflow-hidden rounded-md border border-border bg-surface transition-colors hover:border-accent"
+    >
+      {coverUrl ? (
+        <img
+          src={coverUrl}
+          alt={sequence.name ?? "Sequence cover"}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted">
+          <Film className="h-8 w-8" />
+        </div>
+      )}
+      <span className="pointer-events-none absolute left-1 top-1 flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[10px] font-medium text-foreground shadow-sm backdrop-blur">
+        <Film className="h-3 w-3" />
+        {sequence.capture_count}
+      </span>
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-0.5 bg-gradient-to-t from-black/80 to-transparent px-1.5 py-1">
+        <span className="truncate text-[11px] font-medium text-white">
+          {sequence.name ?? "Untitled sequence"}
+        </span>
+        <span className="text-[10px] text-white/80">{kindLabel}</span>
+        <CreatorBadge
+          authorId={authorId}
+          showName={false}
+          className="self-end"
+        />
+      </div>
+    </Link>
+  );
+}
+
+function splitCompound(id: string, authorId: string): [string, string] {
+  const idx = id.indexOf(":");
+  if (idx < 0) return [authorId, id];
+  return [id.slice(0, idx), id.slice(idx + 1)];
+}

--- a/src/components/capture/SequenceTags.tsx
+++ b/src/components/capture/SequenceTags.tsx
@@ -1,0 +1,59 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useSequenceFullTags } from "@/lib/api/hooks";
+import { createSequenceTag } from "@/lib/mapky-specs";
+import { TagStrip } from "@/components/shared/TagStrip";
+import type {
+  PostTagDetails,
+  SequenceFullResponse,
+} from "@/types/mapky";
+
+interface SequenceTagsProps {
+  authorId: string;
+  sequenceId: string;
+}
+
+/**
+ * Tag strip on a sequence detail page. Reads + writes the composite
+ * `/sequences/{author}/{id}/full` cache so opening the panel fires
+ * one network round-trip total (no separate /tags request).
+ *
+ * Composite-aware via `mutate` + `refresh` callbacks (the same API
+ * `PlaceTags` uses). The legacy per-endpoint `/tags` cache is also
+ * mirrored on the optimistic write so any stand-alone consumer
+ * (search-result rows, future tag chips) sees the change too.
+ */
+export function SequenceTags({ authorId, sequenceId }: SequenceTagsProps) {
+  const { data: tags } = useSequenceFullTags(authorId, sequenceId);
+  const queryClient = useQueryClient();
+  const fullKey = ["mapky", "sequence-full", authorId, sequenceId] as const;
+
+  return (
+    <TagStrip
+      tags={tags}
+      buildTag={(publicKey, label) =>
+        createSequenceTag(publicKey, authorId, sequenceId, label)
+      }
+      mutate={async (updater) => {
+        await queryClient.cancelQueries({ queryKey: fullKey });
+        queryClient.setQueryData<SequenceFullResponse>(fullKey, (old) => {
+          if (!old) return old;
+          const nextTags = updater(old.tags) ?? [];
+          return { ...old, tags: nextTags };
+        });
+        queryClient.setQueryData<PostTagDetails[]>(
+          ["mapky", "sequence", authorId, sequenceId, "tags"],
+          (old) => updater(old),
+        );
+      }}
+      refresh={() => {
+        queryClient.invalidateQueries({ queryKey: fullKey });
+        queryClient.invalidateQueries({
+          queryKey: ["mapky", "sequence", authorId, sequenceId, "tags"],
+        });
+      }}
+      theme="violet"
+      inputMode="free"
+      title="Tags"
+    />
+  );
+}

--- a/src/components/capture/steps/PickStep.tsx
+++ b/src/components/capture/steps/PickStep.tsx
@@ -114,12 +114,15 @@ export function PickStep() {
   const addInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
 
-  const handlePick = async (files: FileList | null) => {
-    if (!files || files.length === 0) return;
+  const handlePick = async (files: FileList | File[] | null) => {
+    if (!files) return;
+    const list = files instanceof FileList ? Array.from(files) : files;
+    if (list.length === 0) return;
     setError(null);
 
-    for (const f of Array.from(files)) {
+    for (const f of list) {
       if (isHeic(f)) {
         setError("HEIC files aren't supported yet — please export as JPEG.");
         return;
@@ -128,7 +131,7 @@ export function PickStep() {
 
     setBusy(true);
     try {
-      const drafts = await Promise.all(Array.from(files).map(fileToDraftItem));
+      const drafts = await Promise.all(list.map(fileToDraftItem));
       setItems(drafts);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not read file");
@@ -136,6 +139,16 @@ export function PickStep() {
       setBusy(false);
     }
   };
+
+  // EXIF GPS-coverage summary across the picked set. Drives the
+  // mix-banner ("4 of 5 have GPS coords"); rendered only when there's
+  // an actual mix so the banner stays informative rather than noisy.
+  const gpsStats = (() => {
+    if (items.length <= 1) return null;
+    const withGps = items.filter((i) => i.lat != null && i.lon != null).length;
+    if (withGps === 0 || withGps === items.length) return null;
+    return { withGps, total: items.length };
+  })();
 
   const handleAddMore = async (files: FileList | null) => {
     if (!files || files.length === 0) return;
@@ -174,18 +187,47 @@ export function PickStep() {
             type="button"
             onClick={() => inputRef.current?.click()}
             disabled={busy}
-            className="flex aspect-video w-full flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-border bg-surface/40 text-muted transition-all hover:border-sky-500/60 hover:bg-sky-500/5 hover:text-sky-600 disabled:opacity-50"
+            onDragEnter={(e) => {
+              e.preventDefault();
+              setDragActive(true);
+            }}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragActive(true);
+            }}
+            onDragLeave={(e) => {
+              e.preventDefault();
+              setDragActive(false);
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragActive(false);
+              const dropped = Array.from(e.dataTransfer.files).filter(
+                (f) =>
+                  f.type.startsWith("image/") || f.type.startsWith("video/"),
+              );
+              if (dropped.length > 0) handlePick(dropped);
+            }}
+            className={`flex aspect-video w-full flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed text-muted transition-all disabled:opacity-50 ${
+              dragActive
+                ? "border-sky-500 bg-sky-500/10 text-sky-700 dark:text-sky-300"
+                : "border-border bg-surface/40 hover:border-sky-500/60 hover:bg-sky-500/5 hover:text-sky-600"
+            }`}
           >
             <Upload className="h-8 w-8" />
             <div className="text-sm font-medium">
-              {busy ? "Reading files…" : "Tap to pick one or more files"}
+              {busy
+                ? "Reading files…"
+                : dragActive
+                  ? "Release to add"
+                  : "Drag photos here or click to pick files"}
             </div>
             <div className="text-xs">
               Pick multiple to build a Street View-style sequence
             </div>
           </button>
           <div className="text-center text-[10px] text-muted">
-            JPEG · PNG · WebP · MP4 · WebM · MOV
+            JPEG · PNG · WebP · MP4 · WebM · MOV · EXIF GPS auto-detected
           </div>
         </>
       ) : (
@@ -196,6 +238,22 @@ export function PickStep() {
               <Layers className="h-3.5 w-3.5" />
               <span>
                 Sequence · <strong>{items.length}</strong> captures
+              </span>
+            </div>
+          )}
+
+          {/* GPS coverage banner — only when picked set is mixed
+              (some have EXIF coords, some don't). Sets expectations
+              about which items will need manual placement on the
+              next step. */}
+          {gpsStats && (
+            <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+              <MapPin className="h-3.5 w-3.5 shrink-0 translate-y-0.5" />
+              <span>
+                <strong>{gpsStats.withGps} of {gpsStats.total}</strong> files
+                carry GPS coords from EXIF. The remaining{" "}
+                {gpsStats.total - gpsStats.withGps} will need manual placement
+                on the next step.
               </span>
             </div>
           )}

--- a/src/components/map/SequenceCoverageLayer.tsx
+++ b/src/components/map/SequenceCoverageLayer.tsx
@@ -77,11 +77,12 @@ function ensureLayers(map: maplibregl.Map, theme: "light" | "dark") {
             16,
             5,
           ],
-          // Kept light so the line reads as connective tissue between
-          // dots rather than a primary feature — at 0.6 it competed
-          // with the basemap's road network and made the dots harder
-          // to pick out.
-          "line-opacity": 0.35,
+          // Slightly bolder than the original 0.35 — sequences are
+          // first-class now (their own marker layer + detail page),
+          // and the polyline is the spatial signal that ties a
+          // sequence's member dots together. Still subtle enough to
+          // not compete with the basemap's road network.
+          "line-opacity": 0.55,
         },
         layout: {
           "line-cap": "round",

--- a/src/components/map/SequenceMarkersLayer.tsx
+++ b/src/components/map/SequenceMarkersLayer.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import maplibregl from "maplibre-gl";
+import { useMapStore } from "@/stores/map-store";
+import { useUiStore } from "@/stores/ui-store";
+import { useViewportSequences } from "@/lib/api/hooks";
+import type { ViewportBounds } from "@/types/mapky";
+
+const VIOLET = "#7c3aed";
+const VIOLET_DARK = "#5b21b6";
+
+/**
+ * One marker per sequence at the bbox centroid. Visually distinct
+ * from the place layer (teal balloons) and the capture layer (sky
+ * dots) by color (violet) and shape (rounded rect with film icon +
+ * count badge).
+ *
+ * Click → `/sequence/{author}/{id}` opens the SequenceDetailPanel.
+ *
+ * Vanilla-DOM HTML markers (innerHTML, addEventListener) — same
+ * pattern BtcOverlayLayer's cluster bubbles use, dodges the React-
+ * portal-vs-effect race that crashed the basemap in earlier work.
+ *
+ * Sequences without a stored bbox (`min_lat == null`) are skipped —
+ * they aren't yet placeable on the map. They'll appear once a member
+ * capture flushes the bbox via the indexer.
+ */
+export function SequenceMarkersLayer() {
+  const map = useMapStore((s) => s.map);
+  const navigate = useNavigate();
+  const visible = useUiStore((s) => s.capturesLayerVisible); // sequences ride the same toggle as captures
+  const hidden = useUiStore((s) => s.hiddenLayers).has("captures");
+  const enabled = visible && !hidden;
+
+  const [bounds, setBounds] = useState<ViewportBounds | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const update = useCallback(() => {
+    if (!map) return;
+    const b = map.getBounds();
+    setBounds({
+      minLat: b.getSouth(),
+      maxLat: b.getNorth(),
+      minLon: b.getWest(),
+      maxLon: b.getEast(),
+    });
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !enabled) return;
+    update();
+    const onMoveEnd = () => {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(update, 150);
+    };
+    map.on("moveend", onMoveEnd);
+    return () => {
+      map.off("moveend", onMoveEnd);
+      clearTimeout(debounceRef.current);
+    };
+  }, [map, enabled, update]);
+
+  const { data: sequences } = useViewportSequences(enabled ? bounds : null);
+
+  // Stable centroid + author/id so the marker key doesn't churn on
+  // metadata-only changes (e.g. renamed sequence keeps same dot).
+  const items = useMemo(() => {
+    if (!sequences) return [];
+    return sequences
+      .filter(
+        (s) =>
+          s.min_lat != null && s.min_lon != null && s.max_lat != null && s.max_lon != null,
+      )
+      .map((s) => {
+        const [author, id] = s.id.split(":");
+        return {
+          key: s.id,
+          author,
+          id,
+          lat: ((s.min_lat ?? 0) + (s.max_lat ?? 0)) / 2,
+          lon: ((s.min_lon ?? 0) + (s.max_lon ?? 0)) / 2,
+          count: s.capture_count,
+          name: s.name,
+        };
+      });
+  }, [sequences]);
+
+  const markersRef = useRef<Map<string, maplibregl.Marker>>(new Map());
+
+  const renderEl = useCallback(
+    (count: number, name: string | null, author: string, id: string) => {
+      const el = document.createElement("div");
+      el.style.pointerEvents = "auto";
+      el.style.cursor = "pointer";
+      el.setAttribute(
+        "aria-label",
+        `${name ?? "Sequence"} — ${count} capture${count === 1 ? "" : "s"}`,
+      );
+      // Pure inline CSS — outside the React tree, we can't lean on
+      // Tailwind utilities here. Mirrors the bubble shape of the
+      // Mapky / BTC clusters but in violet, with an extra count
+      // badge in the corner.
+      el.innerHTML = `
+        <div style="
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 4px 9px 4px 7px;
+          background: ${VIOLET};
+          color: white;
+          border: 2px solid white;
+          border-radius: 9999px;
+          box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+          font-size: 11px;
+          font-weight: 600;
+          font-variant-numeric: tabular-nums;
+          line-height: 1;
+          white-space: nowrap;
+        ">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"></rect>
+            <line x1="7" y1="2" x2="7" y2="22"></line>
+            <line x1="17" y1="2" x2="17" y2="22"></line>
+            <line x1="2" y1="12" x2="22" y2="12"></line>
+            <line x1="2" y1="7" x2="7" y2="7"></line>
+            <line x1="2" y1="17" x2="7" y2="17"></line>
+            <line x1="17" y1="17" x2="22" y2="17"></line>
+            <line x1="17" y1="7" x2="22" y2="7"></line>
+          </svg>
+          <span>${count}</span>
+        </div>
+      `;
+      el.addEventListener("click", (e) => {
+        e.stopPropagation();
+        navigate({
+          to: "/sequence/$authorId/$sequenceId",
+          params: { authorId: author, sequenceId: id },
+        });
+      });
+      // Force a tiny outline color shade on hover — pure DOM, no Tailwind.
+      el.addEventListener("mouseenter", () => {
+        const inner = el.firstElementChild as HTMLElement | null;
+        if (inner) inner.style.background = VIOLET_DARK;
+      });
+      el.addEventListener("mouseleave", () => {
+        const inner = el.firstElementChild as HTMLElement | null;
+        if (inner) inner.style.background = VIOLET;
+      });
+      return el;
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    if (!map) return;
+    const live = markersRef.current;
+
+    if (!enabled) {
+      for (const m of live.values()) m.remove();
+      live.clear();
+      return;
+    }
+
+    const seen = new Set<string>();
+    for (const item of items) {
+      seen.add(item.key);
+      const existing = live.get(item.key);
+      if (existing) {
+        // Count or position changed — rebuild element. Cheap.
+        const newEl = renderEl(item.count, item.name, item.author, item.id);
+        existing.remove();
+        const m = new maplibregl.Marker({ element: newEl, anchor: "center" })
+          .setLngLat([item.lon, item.lat])
+          .addTo(map);
+        live.set(item.key, m);
+        continue;
+      }
+      const el = renderEl(item.count, item.name, item.author, item.id);
+      const m = new maplibregl.Marker({ element: el, anchor: "center" })
+        .setLngLat([item.lon, item.lat])
+        .addTo(map);
+      live.set(item.key, m);
+    }
+    for (const [key, m] of live) {
+      if (!seen.has(key)) {
+        m.remove();
+        live.delete(key);
+      }
+    }
+  }, [map, enabled, items, renderEl]);
+
+  useEffect(() => {
+    const live = markersRef.current;
+    return () => {
+      for (const m of live.values()) m.remove();
+      live.clear();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/search/SearchPanel.tsx
+++ b/src/components/search/SearchPanel.tsx
@@ -409,7 +409,14 @@ export function SearchPanel({ query, mode }: SearchPanelProps) {
         );
         continue;
       }
-      // sequences / incidents — no detail route yet.
+      if (parentType === "sequences") {
+        navigate({
+          to: "/sequence/$authorId/$sequenceId",
+          params: { authorId: parentAuthor, sequenceId: parentId },
+        });
+        return;
+      }
+      // incidents — no detail route yet.
       return;
     }
   };
@@ -667,22 +674,34 @@ export function SearchPanel({ query, mode }: SearchPanelProps) {
               <div className="px-2 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted">
                 Sequences
               </div>
-              {tagResults.sequences.map((s) => (
-                <div
-                  key={s.id}
-                  className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-surface"
-                >
-                  <Layers className="h-4 w-4 flex-shrink-0 text-accent" />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-foreground">
-                      {s.name || "Untitled sequence"}
-                    </p>
-                    <p className="text-xs text-muted">
-                      {s.capture_count} captures
-                    </p>
-                  </div>
-                </div>
-              ))}
+              {tagResults.sequences.map((s) => {
+                const compoundId = s.id.includes(":")
+                  ? s.id
+                  : `${s.author_id}:${s.id}`;
+                const [authorId, sequenceId] = compoundId.split(":");
+                return (
+                  <button
+                    key={compoundId}
+                    onClick={() =>
+                      navigate({
+                        to: "/sequence/$authorId/$sequenceId",
+                        params: { authorId, sequenceId },
+                      })
+                    }
+                    className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-surface"
+                  >
+                    <Layers className="h-4 w-4 flex-shrink-0 text-accent" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {s.name || "Untitled sequence"}
+                      </p>
+                      <p className="text-xs text-muted">
+                        {s.capture_count} captures
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           )}
 

--- a/src/components/sidebar/nav-items.ts
+++ b/src/components/sidebar/nav-items.ts
@@ -1,5 +1,6 @@
 import {
   Camera,
+  Film,
   FolderHeart,
   MapPin,
   MessageSquare,
@@ -18,6 +19,7 @@ export type NavTarget =
   | "/collections"
   | "/routes"
   | "/captures"
+  | "/sequences"
   | "/my-posts";
 
 export interface NavItem {
@@ -33,6 +35,7 @@ export const MAIN_NAV: NavItem[] = [
   { to: "/collections", label: "Collections", icon: FolderHeart },
   { to: "/routes", label: "Routes", icon: RouteIcon },
   { to: "/captures", label: "Captures", icon: Camera },
+  { to: "/sequences", label: "Sequences", icon: Film },
   { to: "/my-posts", label: "My Posts", icon: MessageSquare, requiresAuth: true },
 ];
 
@@ -50,6 +53,8 @@ export function navMatch(to: NavTarget): string {
       return "/route"; // matches /routes, /route/...
     case "/captures":
       return "/capture"; // matches /captures, /capture/...
+    case "/sequences":
+      return "/sequence"; // matches /sequences, /sequence/...
     case "/my-posts":
       return "/my-posts";
   }

--- a/src/lib/api/hooks.ts
+++ b/src/lib/api/hooks.ts
@@ -23,6 +23,8 @@ import {
   fetchUserPosts,
   fetchUserReviews,
   fetchViewportCaptures,
+  fetchViewportSequences,
+  fetchSequenceDetailFull,
   fetchBtcViewport,
   fetchGeoCaptureDetail,
   fetchGeoCaptureTags,
@@ -58,6 +60,7 @@ import type {
   PlaceFullResponse,
   RouteFull,
   RouteFullJson,
+  SequenceFullResponse,
   ViewportBounds,
   ViewportResponse,
   ViewportLayer,
@@ -618,6 +621,59 @@ export function useSequenceCaptures(
     queryFn: () => fetchSequenceCaptures(authorId!, sequenceId!),
     enabled: !!authorId && !!sequenceId,
   });
+}
+
+/**
+ * Sequence-viewport hook — sequences whose stored bbox overlaps the
+ * current map viewport. Drives the sequence markers layer. Same
+ * `snapBoundsForCache` + `staleTime` pattern as `useViewportCaptures`.
+ */
+export function useViewportSequences(bounds: ViewportBounds | null) {
+  const padded = useMemo(() => snapBoundsForCache(bounds), [bounds]);
+  return useQuery({
+    queryKey: ["mapky", "sequences", "viewport", padded] as const,
+    queryFn: () => fetchViewportSequences(padded!),
+    enabled: !!padded,
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+// ── Sequence composite-detail slice hooks ─────────────────────────────
+//
+// Mirrors `usePlaceFullSlice` — one composite fetch backs every
+// SequenceDetailPanel sub-component, so opening the panel fires a
+// single network round-trip total instead of one per slice.
+
+function sequenceFullKey(authorId: string, sequenceId: string) {
+  return ["mapky", "sequence-full", authorId, sequenceId] as const;
+}
+
+const SEQUENCE_FULL_STALE_MS = 60_000;
+
+function useSequenceFullSlice<T>(
+  authorId: string,
+  sequenceId: string,
+  select: (data: SequenceFullResponse) => T,
+) {
+  return useQuery({
+    queryKey: sequenceFullKey(authorId, sequenceId),
+    queryFn: () => fetchSequenceDetailFull(authorId, sequenceId),
+    enabled: !!authorId && !!sequenceId,
+    staleTime: SEQUENCE_FULL_STALE_MS,
+    retry: noRetryOn404,
+    select,
+  });
+}
+
+export function useSequenceFullDetail(authorId: string, sequenceId: string) {
+  return useSequenceFullSlice(authorId, sequenceId, (d) => d.detail);
+}
+export function useSequenceFullCaptures(authorId: string, sequenceId: string) {
+  return useSequenceFullSlice(authorId, sequenceId, (d) => d.captures);
+}
+export function useSequenceFullTags(authorId: string, sequenceId: string) {
+  return useSequenceFullSlice(authorId, sequenceId, (d) => d.tags);
 }
 
 /**

--- a/src/lib/api/hooks.ts
+++ b/src/lib/api/hooks.ts
@@ -23,6 +23,7 @@ import {
   fetchUserPosts,
   fetchUserReviews,
   fetchViewportCaptures,
+  fetchUserSequences,
   fetchViewportSequences,
   fetchSequenceDetailFull,
   fetchBtcViewport,
@@ -620,6 +621,16 @@ export function useSequenceCaptures(
     queryKey: ["mapky", "sequence", authorId, sequenceId, "captures"],
     queryFn: () => fetchSequenceCaptures(authorId!, sequenceId!),
     enabled: !!authorId && !!sequenceId,
+  });
+}
+
+/** A user's sequences, most-recent first. Backs the "Mine" tab on
+ *  the sequences discover sidebar. */
+export function useUserSequences(userId: string | null) {
+  return useQuery({
+    queryKey: ["mapky", "sequences", "user", userId],
+    queryFn: () => fetchUserSequences(userId!),
+    enabled: !!userId,
   });
 }
 

--- a/src/lib/api/mapky.ts
+++ b/src/lib/api/mapky.ts
@@ -16,6 +16,8 @@ import type {
   PlaceFullResponse,
   BtcViewportResponse,
   BitcoinPoi,
+  SequenceViewportItem,
+  SequenceFullResponse,
 } from "@/types/mapky";
 
 /** Build the `activity` + `min_rating` query params for the place
@@ -449,6 +451,41 @@ export async function fetchSequenceCaptures(
 ): Promise<GeoCaptureDetails[]> {
   const { data } = await nexusClient.get<GeoCaptureDetails[]>(
     `/v0/mapky/sequences/${authorId}/${sequenceId}/captures`,
+  );
+  return data;
+}
+
+/** Sequences whose stored bbox overlaps the viewport. Spatial
+ *  discovery surface for the map's sequence markers layer. */
+export async function fetchViewportSequences(
+  bounds: ViewportBounds,
+  limit = 200,
+): Promise<SequenceViewportItem[]> {
+  const { data } = await nexusClient.get<SequenceViewportItem[]>(
+    "/v0/mapky/sequences/viewport",
+    {
+      params: {
+        min_lat: bounds.minLat,
+        min_lon: bounds.minLon,
+        max_lat: bounds.maxLat,
+        max_lon: bounds.maxLon,
+        limit,
+      },
+    },
+  );
+  return data;
+}
+
+/** Composite sequence-detail fetch — detail + captures + tags in one
+ *  round-trip. Backed by `/sequences/{author}/{id}/full`. */
+export async function fetchSequenceDetailFull(
+  authorId: string,
+  sequenceId: string,
+  capturesLimit = 100,
+): Promise<SequenceFullResponse> {
+  const { data } = await nexusClient.get<SequenceFullResponse>(
+    `/v0/mapky/sequences/${authorId}/${sequenceId}/full`,
+    { params: { captures_limit: capturesLimit } },
   );
   return data;
 }

--- a/src/lib/api/mapky.ts
+++ b/src/lib/api/mapky.ts
@@ -16,6 +16,7 @@ import type {
   PlaceFullResponse,
   BtcViewportResponse,
   BitcoinPoi,
+  SequenceDetails,
   SequenceViewportItem,
   SequenceFullResponse,
 } from "@/types/mapky";
@@ -451,6 +452,19 @@ export async function fetchSequenceCaptures(
 ): Promise<GeoCaptureDetails[]> {
   const { data } = await nexusClient.get<GeoCaptureDetails[]>(
     `/v0/mapky/sequences/${authorId}/${sequenceId}/captures`,
+  );
+  return data;
+}
+
+/** A user's sequences, most-recent first. Backed by
+ *  `/v0/mapky/sequences/user/{user_id}`. */
+export async function fetchUserSequences(
+  userId: string,
+  limit = 100,
+): Promise<SequenceDetails[]> {
+  const { data } = await nexusClient.get<SequenceDetails[]>(
+    `/v0/mapky/sequences/user/${userId}`,
+    { params: { limit } },
   );
   return data;
 }

--- a/src/lib/mapky-specs.ts
+++ b/src/lib/mapky-specs.ts
@@ -413,6 +413,25 @@ export function createGeoCaptureTag(
   return { path, json };
 }
 
+export function createSequenceTag(
+  pubkyId: string,
+  authorId: string,
+  sequenceId: string,
+  label: string,
+): CreateTagResult {
+  const builder = new MapkySpecsBuilder(pubkyId);
+  const sequenceUri = `pubky://${authorId}/pub/mapky.app/sequences/${sequenceId}`;
+
+  const result = builder.createPlaceTag(sequenceUri, label);
+  const json = JSON.stringify(result.tag.toJson());
+  const path = result.meta.path;
+
+  result.free();
+  builder.free();
+
+  return { path, json };
+}
+
 export type RouteActivityKey =
   | "hiking"
   | "cycling"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as CollectionsRouteImport } from './routes/collections'
 import { Route as CapturesRouteImport } from './routes/captures'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RoutesIndexRouteImport } from './routes/routes/index'
+import { Route as SequenceAuthorIdSequenceIdRouteImport } from './routes/sequence/$authorId.$sequenceId'
 import { Route as RouteAuthorIdRouteIdRouteImport } from './routes/route/$authorId.$routeId'
 import { Route as PlaceOsmTypeOsmIdRouteImport } from './routes/place/$osmType.$osmId'
 import { Route as CollectionAuthorIdCollectionIdRouteImport } from './routes/collection/$authorId.$collectionId'
@@ -68,6 +69,12 @@ const RoutesIndexRoute = RoutesIndexRouteImport.update({
   path: '/routes/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SequenceAuthorIdSequenceIdRoute =
+  SequenceAuthorIdSequenceIdRouteImport.update({
+    id: '/sequence/$authorId/$sequenceId',
+    path: '/sequence/$authorId/$sequenceId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const RouteAuthorIdRouteIdRoute = RouteAuthorIdRouteIdRouteImport.update({
   id: '/route/$authorId/$routeId',
   path: '/route/$authorId/$routeId',
@@ -105,6 +112,7 @@ export interface FileRoutesByFullPath {
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
   '/place/$osmType/$osmId': typeof PlaceOsmTypeOsmIdRoute
   '/route/$authorId/$routeId': typeof RouteAuthorIdRouteIdRoute
+  '/sequence/$authorId/$sequenceId': typeof SequenceAuthorIdSequenceIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -120,6 +128,7 @@ export interface FileRoutesByTo {
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
   '/place/$osmType/$osmId': typeof PlaceOsmTypeOsmIdRoute
   '/route/$authorId/$routeId': typeof RouteAuthorIdRouteIdRoute
+  '/sequence/$authorId/$sequenceId': typeof SequenceAuthorIdSequenceIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -136,6 +145,7 @@ export interface FileRoutesById {
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
   '/place/$osmType/$osmId': typeof PlaceOsmTypeOsmIdRoute
   '/route/$authorId/$routeId': typeof RouteAuthorIdRouteIdRoute
+  '/sequence/$authorId/$sequenceId': typeof SequenceAuthorIdSequenceIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -153,6 +163,7 @@ export interface FileRouteTypes {
     | '/collection/$authorId/$collectionId'
     | '/place/$osmType/$osmId'
     | '/route/$authorId/$routeId'
+    | '/sequence/$authorId/$sequenceId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -168,6 +179,7 @@ export interface FileRouteTypes {
     | '/collection/$authorId/$collectionId'
     | '/place/$osmType/$osmId'
     | '/route/$authorId/$routeId'
+    | '/sequence/$authorId/$sequenceId'
   id:
     | '__root__'
     | '/'
@@ -183,6 +195,7 @@ export interface FileRouteTypes {
     | '/collection/$authorId/$collectionId'
     | '/place/$osmType/$osmId'
     | '/route/$authorId/$routeId'
+    | '/sequence/$authorId/$sequenceId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -199,6 +212,7 @@ export interface RootRouteChildren {
   CollectionAuthorIdCollectionIdRoute: typeof CollectionAuthorIdCollectionIdRoute
   PlaceOsmTypeOsmIdRoute: typeof PlaceOsmTypeOsmIdRoute
   RouteAuthorIdRouteIdRoute: typeof RouteAuthorIdRouteIdRoute
+  SequenceAuthorIdSequenceIdRoute: typeof SequenceAuthorIdSequenceIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -266,6 +280,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RoutesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/sequence/$authorId/$sequenceId': {
+      id: '/sequence/$authorId/$sequenceId'
+      path: '/sequence/$authorId/$sequenceId'
+      fullPath: '/sequence/$authorId/$sequenceId'
+      preLoaderRoute: typeof SequenceAuthorIdSequenceIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/route/$authorId/$routeId': {
       id: '/route/$authorId/$routeId'
       path: '/route/$authorId/$routeId'
@@ -311,6 +332,7 @@ const rootRouteChildren: RootRouteChildren = {
   CollectionAuthorIdCollectionIdRoute: CollectionAuthorIdCollectionIdRoute,
   PlaceOsmTypeOsmIdRoute: PlaceOsmTypeOsmIdRoute,
   RouteAuthorIdRouteIdRoute: RouteAuthorIdRouteIdRoute,
+  SequenceAuthorIdSequenceIdRoute: SequenceAuthorIdSequenceIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SequencesRouteImport } from './routes/sequences'
 import { Route as SearchRouteImport } from './routes/search'
 import { Route as PlacesRouteImport } from './routes/places'
 import { Route as MyPostsRouteImport } from './routes/my-posts'
@@ -24,6 +25,11 @@ import { Route as PlaceOsmTypeOsmIdRouteImport } from './routes/place/$osmType.$
 import { Route as CollectionAuthorIdCollectionIdRouteImport } from './routes/collection/$authorId.$collectionId'
 import { Route as CaptureAuthorIdCaptureIdRouteImport } from './routes/capture/$authorId.$captureId'
 
+const SequencesRoute = SequencesRouteImport.update({
+  id: '/sequences',
+  path: '/sequences',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SearchRoute = SearchRouteImport.update({
   id: '/search',
   path: '/search',
@@ -107,6 +113,7 @@ export interface FileRoutesByFullPath {
   '/my-posts': typeof MyPostsRoute
   '/places': typeof PlacesRoute
   '/search': typeof SearchRoute
+  '/sequences': typeof SequencesRoute
   '/routes/': typeof RoutesIndexRoute
   '/capture/$authorId/$captureId': typeof CaptureAuthorIdCaptureIdRoute
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
@@ -123,6 +130,7 @@ export interface FileRoutesByTo {
   '/my-posts': typeof MyPostsRoute
   '/places': typeof PlacesRoute
   '/search': typeof SearchRoute
+  '/sequences': typeof SequencesRoute
   '/routes': typeof RoutesIndexRoute
   '/capture/$authorId/$captureId': typeof CaptureAuthorIdCaptureIdRoute
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
@@ -140,6 +148,7 @@ export interface FileRoutesById {
   '/my-posts': typeof MyPostsRoute
   '/places': typeof PlacesRoute
   '/search': typeof SearchRoute
+  '/sequences': typeof SequencesRoute
   '/routes/': typeof RoutesIndexRoute
   '/capture/$authorId/$captureId': typeof CaptureAuthorIdCaptureIdRoute
   '/collection/$authorId/$collectionId': typeof CollectionAuthorIdCollectionIdRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
     | '/my-posts'
     | '/places'
     | '/search'
+    | '/sequences'
     | '/routes/'
     | '/capture/$authorId/$captureId'
     | '/collection/$authorId/$collectionId'
@@ -174,6 +184,7 @@ export interface FileRouteTypes {
     | '/my-posts'
     | '/places'
     | '/search'
+    | '/sequences'
     | '/routes'
     | '/capture/$authorId/$captureId'
     | '/collection/$authorId/$collectionId'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '/my-posts'
     | '/places'
     | '/search'
+    | '/sequences'
     | '/routes/'
     | '/capture/$authorId/$captureId'
     | '/collection/$authorId/$collectionId'
@@ -207,6 +219,7 @@ export interface RootRouteChildren {
   MyPostsRoute: typeof MyPostsRoute
   PlacesRoute: typeof PlacesRoute
   SearchRoute: typeof SearchRoute
+  SequencesRoute: typeof SequencesRoute
   RoutesIndexRoute: typeof RoutesIndexRoute
   CaptureAuthorIdCaptureIdRoute: typeof CaptureAuthorIdCaptureIdRoute
   CollectionAuthorIdCollectionIdRoute: typeof CollectionAuthorIdCollectionIdRoute
@@ -217,6 +230,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sequences': {
+      id: '/sequences'
+      path: '/sequences'
+      fullPath: '/sequences'
+      preLoaderRoute: typeof SequencesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/search': {
       id: '/search'
       path: '/search'
@@ -327,6 +347,7 @@ const rootRouteChildren: RootRouteChildren = {
   MyPostsRoute: MyPostsRoute,
   PlacesRoute: PlacesRoute,
   SearchRoute: SearchRoute,
+  SequencesRoute: SequencesRoute,
   RoutesIndexRoute: RoutesIndexRoute,
   CaptureAuthorIdCaptureIdRoute: CaptureAuthorIdCaptureIdRoute,
   CollectionAuthorIdCollectionIdRoute: CollectionAuthorIdCollectionIdRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { MapView } from "@/components/map/MapView";
 import { PlaceAnnotationsLayer } from "@/components/map/PlaceAnnotationsLayer";
 import { CaptureMarkersLayer } from "@/components/map/CaptureMarkersLayer";
 import { SequenceCoverageLayer } from "@/components/map/SequenceCoverageLayer";
+import { SequenceMarkersLayer } from "@/components/map/SequenceMarkersLayer";
 import { PoiClickHandler } from "@/components/map/PoiClickHandler";
 import { SelectedPlaceMarker } from "@/components/map/SelectedPlaceMarker";
 import { RailOverlayLayer } from "@/components/map/RailOverlayLayer";
@@ -35,6 +36,7 @@ function RootLayout() {
           <PlaceAnnotationsLayer />
           <CaptureMarkersLayer />
           <SequenceCoverageLayer />
+          <SequenceMarkersLayer />
           <MainMapCaptureOverlay />
           <RailOverlayLayer />
           <BtcOverlayLayer />

--- a/src/routes/sequence/$authorId.$sequenceId.tsx
+++ b/src/routes/sequence/$authorId.$sequenceId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SequenceDetailPanel } from "@/components/capture/SequenceDetailPanel";
+
+export const Route = createFileRoute("/sequence/$authorId/$sequenceId")({
+  component: SequenceDetailRoute,
+});
+
+function SequenceDetailRoute() {
+  const { authorId, sequenceId } = Route.useParams();
+  return <SequenceDetailPanel authorId={authorId} sequenceId={sequenceId} />;
+}

--- a/src/routes/sequences.tsx
+++ b/src/routes/sequences.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SequenceList } from "@/components/capture/SequenceList";
+
+export const Route = createFileRoute("/sequences")({
+  component: SequenceList,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: "mine" | "viewport" } => ({
+    tab:
+      search.tab === "mine" || search.tab === "viewport"
+        ? search.tab
+        : undefined,
+  }),
+});

--- a/src/types/mapky.ts
+++ b/src/types/mapky.ts
@@ -222,6 +222,24 @@ export interface SequenceDetails {
   max_lon: number | null;
   device: string | null;
   indexed_at: number;
+  /** Optional tags slice — populated by `/sequences/{a}/{s}` and the
+   *  composite endpoint, omitted on viewport-list responses. */
+  tags?: PostTagDetails[];
+}
+
+/** One row from `/v0/mapky/sequences/viewport`. SequenceDetails plus a
+ *  cover-thumbnail file_uri picked from the lowest-index member
+ *  capture (used as the marker / list cover image). */
+export interface SequenceViewportItem extends SequenceDetails {
+  cover_uri: string | null;
+}
+
+/** Composite envelope from `/v0/mapky/sequences/{author}/{id}/full`.
+ *  Detail + member captures + tags in one round-trip. */
+export interface SequenceFullResponse {
+  detail: SequenceDetails;
+  captures: GeoCaptureDetails[];
+  tags: PostTagDetails[];
 }
 
 export interface TagSearchResult {


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the geo-captures + sequences feature. Sequences are now first-class on Mapky on par with captures, with their own clickable map markers, detail page, tags, discussion threads, discover sidebar, and search-result navigation.

Server-side counterpart: gillohner/mapky-nexus-plugin#3 (must be deployed for the new endpoints to resolve).

## Phases

### 1. Plugin endpoints
Two new endpoints (server PR #3):
- \`GET /v0/mapky/sequences/viewport\` — bbox-overlap discovery
- \`GET /v0/mapky/sequences/{author}/{id}/full\` — composite (detail + captures + tags)

### 2. Map: sequence markers
- New \`<SequenceMarkersLayer />\` — vanilla-DOM HTML markers (violet pill with film icon + count badge) at each sequence's bbox centroid. Click → \`/sequence/{author}/{id}\`.
- \`<SequenceCoverageLayer />\` polyline opacity lifted 0.35→0.55 since sequences are first-class now.
- Rides the same toggle as captures.

### 3. Sequence detail page
- New route: \`/sequence/\$authorId/\$sequenceId\`
- \`<SequenceDetailPanel />\`: header (author, kind, count, time range, device) + description + tags + 3-col CaptureCard grid + reply thread.
- Reads off the new composite cache via slice hooks (\`useSequenceFullDetail/Captures/Tags\`) — opens the panel in ONE network round-trip.
- fitBounds the map to the sequence's bbox on mount; pins member captures so they stay drawn while the user pans.
- Mobile: drops into MobileBottomSheet via DiscoverSidebar.

### 4. Discovery + search
- New route: \`/sequences\` — Mine + In this area discover sidebar (mirrors \`/captures\`).
- \`<SequenceList />\` — 2-col cover-thumbnail grid, name filter, freeze-bbox-while-filtering pattern.
- \`<IconRail />\` + \`<MobileNavDrawer />\` — Sequences nav entry (Film icon).
- \`<SearchPanel />\` — sequence rows in tag search are clickable, navigating to /sequence/...; back-walks through reply ancestors resolve sequence parents (was 'no detail route yet').

### 5. Capture creation polish
- Drag-drop on the empty PickStep zone.
- EXIF coverage banner: when a multi-file pick has a MIX of files with/without GPS coords, show 'X of Y files carry GPS coords; the remaining N will need manual placement.'

### 6. Refactor
- \`CaptureCard\` hoisted from \`<CaptureList />\` into its own module so \`<SequenceDetailPanel />\` can reuse it. Helpers (\`splitCompound\`, \`thumbnailUrl\`, \`kindIcon\`, \`KIND_LABELS\`) move with it.
- New \`createSequenceTag\` in \`mapky-specs.ts\` (mirrors \`createGeoCaptureTag\`).
- \`TagStrip\` already supports composite-cache callers (mutate + refresh from earlier work); \`<SequenceTags />\` uses that path.
- \`useUserProfile\` + \`useEnsureIngested\` on the sequence panel for unknown-author cases (mirrors ReplyThread).

## Test plan
- [x] \`npm run build\` clean, \`npx tsc --noEmit\` clean
- [ ] Rebuild + restart nexusd against gillohner/mapky-nexus-plugin#3
- [ ] Sequence on map: open at a known seeded sequence area → violet marker visible → click → detail panel renders with captures grid
- [ ] Tag a sequence → tag chip appears, persists across page reload (composite-cache write + invalidate path)
- [ ] Reply on a sequence → comment thread renders via ResourceDiscussion
- [ ] Pick 3 photos with mixed GPS → see banner 'X of 3 carry GPS coords' → upload → sequence appears on map → click → 3 captures in grid
- [ ] Drop a JPEG onto the empty PickStep zone → file gets picked
- [ ] Search 'coffee' → click a sequence result → land on detail page
- [ ] /sequences route renders the discover sidebar; Mine tab lists user's sequences; viewport tab lists nearby