### PR TITLE
Fix optimistic caching for place activity

### DIFF
--- a/src/components/place/CommentForm.tsx
+++ b/src/components/place/CommentForm.tsx
@@ -21,10 +21,10 @@ import type { MapkyPostDetails } from "@/types/mapky";
  * nexus has indexed the new post — instead of blanket-invalidating
  * `["mapky"]` and stomping every concurrent optimistic update.
  *
- * Returns null when the parent is unrecognized (cross-domain or absent);
- * in that case we skip the refetch and rely on the optimistic state. */
-function parentListQueryKey(parent: string | null | undefined): QueryKey | null {
-  if (!parent) return null;
+ * Returns an empty array when the parent is unrecognized (cross-domain or
+ * absent); in that case we skip the refetch and rely on optimistic state. */
+function parentListQueryKeys(parent: string | null | undefined): QueryKey[] {
+  if (!parent) return [];
 
   // OSM URL → place posts list
   const osm = parent.match(
@@ -33,7 +33,10 @@ function parentListQueryKey(parent: string | null | undefined): QueryKey | null 
   if (osm) {
     const osmType = osm[1];
     const osmId = Number(osm[2]);
-    return ["mapky", "place", osmType, osmId, "posts"];
+    return [
+      ["mapky", "place-full", osmType, osmId],
+      ["mapky", "place", osmType, osmId, "posts"],
+    ];
   }
 
   // pubky://{author}/pub/mapky.app/{type}/{id} → that resource's reply list
@@ -41,10 +44,10 @@ function parentListQueryKey(parent: string | null | undefined): QueryKey | null 
     /^pubky:\/\/([^/]+)\/pub\/mapky\.app\/(reviews|routes|collections|geo_captures|sequences|incidents|posts)\/([^/?#]+)/,
   );
   if (mapky) {
-    return ["mapky", mapky[2], mapky[1], mapky[3], "replies"];
+    return [["mapky", mapky[2], mapky[1], mapky[3], "replies"]];
   }
 
-  return null;
+  return [];
 }
 
 interface CommentFormProps {
@@ -172,7 +175,7 @@ export function CommentForm({
       // Each submit owns its own closure — rapid back-to-back posts no
       // longer pile up on a single 5 s timer that wipes everyone's
       // optimistic state.
-      const refetchKey = parentListQueryKey(
+      const refetchKeys = parentListQueryKeys(
         parent ?? editPost?.parent_uri ?? null,
       );
       const writtenPostId = postId;
@@ -188,8 +191,10 @@ export function CommentForm({
           },
           { intervalMs: 600, timeoutMs: 30_000, initialDelayMs: 800 },
         );
-        if (indexed && refetchKey) {
-          queryClient.refetchQueries({ queryKey: refetchKey, type: "active" });
+        if (indexed) {
+          for (const queryKey of refetchKeys) {
+            queryClient.refetchQueries({ queryKey, type: "active" });
+          }
         }
       });
     } catch (err) {

--- a/src/components/place/PlaceActions.tsx
+++ b/src/components/place/PlaceActions.tsx
@@ -3,7 +3,8 @@ import { MessageSquarePlus, Star, FolderHeart } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { makeOsmUrl } from "@/lib/mapky-specs";
-import type { MapkyPostDetails } from "@/types/mapky";
+import { registerPending } from "@/lib/api/optimistic-overlay";
+import type { MapkyPostDetails, PlaceFullResponse } from "@/types/mapky";
 import { ReviewForm } from "./ReviewForm";
 import { CommentForm } from "./CommentForm";
 import { CollectionPicker } from "@/components/collection/CollectionPicker";
@@ -13,6 +14,40 @@ interface PlaceActionsProps {
   osmId: number;
 }
 
+const samePost = (a: MapkyPostDetails, b: MapkyPostDetails) =>
+  a.id === b.id && a.author_id === b.author_id;
+
+function upsertPost(posts: MapkyPostDetails[], post: MapkyPostDetails) {
+  const existing = posts.some((p) => samePost(p, post));
+  return existing
+    ? posts.map((p) => (samePost(p, post) ? post : p))
+    : [post, ...posts];
+}
+
+function emptyPlaceFull(osmType: string, osmId: number): PlaceFullResponse {
+  return {
+    detail: {
+      osm_canonical: makeOsmUrl(osmType, osmId),
+      osm_type: osmType,
+      osm_id: osmId,
+      lat: 0,
+      lon: 0,
+      geocoded: false,
+      review_count: 0,
+      avg_rating: 0,
+      tag_count: 0,
+      photo_count: 0,
+      indexed_at: Math.floor(Date.now() / 1000),
+      name: null,
+    },
+    reviews: [],
+    posts: [],
+    tags: [],
+    collections: [],
+    routes: [],
+  };
+}
+
 /**
  * Workflow triggers on a place panel. Tagging used to live here too,
  * but it's now handled by the inline `<PlaceTags />` strip's `+` button
@@ -20,7 +55,7 @@ interface PlaceActionsProps {
  * places are public OSM data, and Share lives in the panel header.
  */
 export function PlaceActions({ osmType, osmId }: PlaceActionsProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, publicKey } = useAuth();
   const queryClient = useQueryClient();
   const [formMode, setFormMode] =
     useState<"review" | "post" | "collect" | null>(null);
@@ -43,10 +78,37 @@ export function PlaceActions({ osmType, osmId }: PlaceActionsProps) {
         parentPreview={`About ${osmType}/${osmId}`}
         onClose={() => setFormMode(null)}
         onPosted={(post: MapkyPostDetails) => {
+          const placeFullKey = ["mapky", "place-full", osmType, osmId] as const;
+          const pendingId = `post:${post.author_id}:${post.id}`;
+
+          registerPending<PlaceFullResponse>(placeFullKey, {
+            id: pendingId,
+            apply: (data) => ({
+              ...data,
+              posts: upsertPost(data.posts, post),
+            }),
+            isConfirmed: (data) =>
+              data.posts.some(
+                (p) =>
+                  samePost(p, post) &&
+                  p.content === post.content &&
+                  p.attachments.length === post.attachments.length,
+              ),
+          });
+
+          queryClient.setQueryData<PlaceFullResponse>(placeFullKey, (old) =>
+            old ? { ...old } : emptyPlaceFull(osmType, osmId),
+          );
           queryClient.setQueryData<MapkyPostDetails[]>(
             ["mapky", "place", osmType, osmId, "posts"],
-            (old) => (old ? [post, ...old] : [post]),
+            (old) => (old ? upsertPost(old, post) : [post]),
           );
+          if (publicKey) {
+            queryClient.setQueryData<MapkyPostDetails[]>(
+              ["mapky", "posts", "user", publicKey],
+              (old) => (old ? upsertPost(old, post) : [post]),
+            );
+          }
         }}
       />
     );

--- a/src/components/place/PlaceTags.tsx
+++ b/src/components/place/PlaceTags.tsx
@@ -1,6 +1,7 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePlaceFullTags } from "@/lib/api/hooks";
-import { createPlaceTag } from "@/lib/mapky-specs";
+import { fetchOsmResourceTags } from "@/lib/api/mapky";
+import { createPlaceTag, makeOsmUrl } from "@/lib/mapky-specs";
 import { TagStrip } from "@/components/shared/TagStrip";
 import type {
   PlaceDetails,
@@ -11,6 +12,30 @@ import type {
 interface PlaceTagsProps {
   osmType: string;
   osmId: number;
+}
+
+function emptyPlaceFull(osmType: string, osmId: number): PlaceFullResponse {
+  return {
+    detail: {
+      osm_canonical: makeOsmUrl(osmType, osmId),
+      osm_type: osmType,
+      osm_id: osmId,
+      lat: 0,
+      lon: 0,
+      geocoded: false,
+      review_count: 0,
+      avg_rating: 0,
+      tag_count: 0,
+      photo_count: 0,
+      indexed_at: Math.floor(Date.now() / 1000),
+      name: null,
+    },
+    reviews: [],
+    posts: [],
+    tags: [],
+    collections: [],
+    routes: [],
+  };
 }
 
 /**
@@ -29,9 +54,17 @@ interface PlaceTagsProps {
  * in sync on tag_count.
  */
 export function PlaceTags({ osmType, osmId }: PlaceTagsProps) {
-  const { data: tags } = usePlaceFullTags(osmType, osmId);
+  const { data: placeFullTags } = usePlaceFullTags(osmType, osmId);
   const queryClient = useQueryClient();
   const fullKey = ["mapky", "place-full", osmType, osmId] as const;
+  const resourceTagsKey = ["mapky", "place", osmType, osmId, "resource-tags"] as const;
+  const { data: resourceTags } = useQuery({
+    queryKey: resourceTagsKey,
+    queryFn: () => fetchOsmResourceTags(osmType, osmId),
+    enabled: !!osmType && !!osmId && (!placeFullTags || placeFullTags.length === 0),
+    retry: false,
+  });
+  const tags = placeFullTags && placeFullTags.length > 0 ? placeFullTags : resourceTags;
 
   return (
     <TagStrip
@@ -42,9 +75,9 @@ export function PlaceTags({ osmType, osmId }: PlaceTagsProps) {
       mutate={async (updater) => {
         await queryClient.cancelQueries({ queryKey: fullKey });
         queryClient.setQueryData<PlaceFullResponse>(fullKey, (old) => {
-          if (!old) return old;
-          const nextTags = updater(old.tags) ?? [];
-          return { ...old, tags: nextTags };
+          const base = old ?? emptyPlaceFull(osmType, osmId);
+          const nextTags = updater(base.tags) ?? [];
+          return { ...base, tags: nextTags };
         });
         // Also feed the legacy per-endpoint /tags cache so any non-
         // composite consumer (e.g. PlaceList row tag chips) sees the
@@ -53,9 +86,13 @@ export function PlaceTags({ osmType, osmId }: PlaceTagsProps) {
           ["mapky", "place", osmType, osmId, "tags"],
           (old) => updater(old),
         );
+        queryClient.setQueryData<PostTagDetails[]>(resourceTagsKey, (old) =>
+          updater(old),
+        );
       }}
       refresh={() => {
         queryClient.invalidateQueries({ queryKey: fullKey });
+        queryClient.invalidateQueries({ queryKey: resourceTagsKey });
         queryClient.invalidateQueries({
           queryKey: ["mapky", "place", osmType, osmId, "tags"],
         });

--- a/src/components/place/ReviewForm.tsx
+++ b/src/components/place/ReviewForm.tsx
@@ -6,6 +6,7 @@ import { createReview, makeOsmUrl } from "@/lib/mapky-specs";
 import { ingestUserIntoNexus } from "@/lib/nexus/ingest";
 import { fetchReviewTags } from "@/lib/api/mapky";
 import { waitForIndexed } from "@/lib/api/wait-for-indexed";
+import { registerPending } from "@/lib/api/optimistic-overlay";
 import {
   uploadFile,
   ACCEPTED_IMAGE_TYPES,
@@ -14,7 +15,7 @@ import {
 } from "@/lib/pubky/files";
 import { toast } from "sonner";
 import { resolveFileUrl } from "@/lib/api/user";
-import type { ReviewDetails, PlaceDetails } from "@/types/mapky";
+import type { ReviewDetails, PlaceDetails, PlaceFullResponse } from "@/types/mapky";
 
 interface ReviewFormProps {
   osmType: string;
@@ -27,6 +28,70 @@ interface ReviewFormProps {
 interface PendingImage {
   file: File;
   previewUrl: string;
+}
+
+const sameReview = (a: ReviewDetails, b: ReviewDetails) =>
+  a.id === b.id && a.author_id === b.author_id;
+
+function upsertReview(reviews: ReviewDetails[], review: ReviewDetails) {
+  const existing = reviews.some((r) => sameReview(r, review));
+  return existing
+    ? reviews.map((r) => (sameReview(r, review) ? review : r))
+    : [review, ...reviews];
+}
+
+function emptyPlaceFull(osmType: string, osmId: number): PlaceFullResponse {
+  return {
+    detail: {
+      osm_canonical: makeOsmUrl(osmType, osmId),
+      osm_type: osmType,
+      osm_id: osmId,
+      lat: 0,
+      lon: 0,
+      geocoded: false,
+      review_count: 0,
+      avg_rating: 0,
+      tag_count: 0,
+      photo_count: 0,
+      indexed_at: Math.floor(Date.now() / 1000),
+      name: null,
+    },
+    reviews: [],
+    posts: [],
+    tags: [],
+    collections: [],
+    routes: [],
+  };
+}
+
+function patchPlaceFullReview(
+  data: PlaceFullResponse,
+  review: ReviewDetails,
+  previousReview: ReviewDetails | undefined,
+  addedPhotos: number,
+): PlaceFullResponse {
+  const isNew = !previousReview && !data.reviews.some((r) => sameReview(r, review));
+  const currentCount = data.detail.review_count;
+  const nextCount = isNew ? currentCount + 1 : currentCount;
+  const previousRating = previousReview?.rating;
+  const nextAvg = previousRating
+    ? (data.detail.avg_rating * currentCount - previousRating + review.rating) /
+      Math.max(currentCount, 1)
+    : isNew
+      ? (data.detail.avg_rating * currentCount + review.rating) /
+        Math.max(nextCount, 1)
+      : data.detail.avg_rating;
+
+  return {
+    ...data,
+    reviews: upsertReview(data.reviews, review),
+    detail: {
+      ...data.detail,
+      review_count: nextCount,
+      avg_rating: nextAvg,
+      photo_count: data.detail.photo_count + addedPhotos,
+    },
+  };
 }
 
 export function ReviewForm({ osmType, osmId, onClose, editReview }: ReviewFormProps) {
@@ -99,6 +164,12 @@ export function ReviewForm({ osmType, osmId, onClose, editReview }: ReviewFormPr
       await queryClient.cancelQueries({
         queryKey: ["mapky", "place", osmType, osmId],
       });
+      await queryClient.cancelQueries({
+        queryKey: ["mapky", "place-full", osmType, osmId],
+      });
+      await queryClient.cancelQueries({
+        queryKey: ["mapky", "reviews", "user", publicKey],
+      });
 
       const reviewId = editReview?.id ?? result.path.split("/").pop()!;
       const optimistic: ReviewDetails = {
@@ -110,6 +181,33 @@ export function ReviewForm({ osmType, osmId, onClose, editReview }: ReviewFormPr
         attachments: allAttachments,
         indexed_at: editReview?.indexed_at ?? Math.floor(Date.now() / 1000),
       };
+
+      const placeFullKey = ["mapky", "place-full", osmType, osmId] as const;
+      const userReviewsKey = ["mapky", "reviews", "user", publicKey] as const;
+      const pendingId = `review:${publicKey}:${reviewId}`;
+      const reviewConfirmed = (data: PlaceFullResponse) =>
+        data.reviews.some(
+          (r) =>
+            sameReview(r, optimistic) &&
+            r.rating === optimistic.rating &&
+            r.content === optimistic.content &&
+            r.attachments.length === optimistic.attachments.length,
+        );
+
+      registerPending<PlaceFullResponse>(placeFullKey, {
+        id: pendingId,
+        apply: (data) =>
+          patchPlaceFullReview(data, optimistic, editReview, newAttachments.length),
+        isConfirmed: reviewConfirmed,
+      });
+
+      queryClient.setQueryData<PlaceFullResponse>(placeFullKey, (old) =>
+        old ? { ...old } : emptyPlaceFull(osmType, osmId),
+      );
+
+      queryClient.setQueryData<ReviewDetails[]>(userReviewsKey, (old) =>
+        old ? upsertReview(old, optimistic) : [optimistic],
+      );
 
       if (editReview) {
         queryClient.setQueryData<ReviewDetails[]>(
@@ -168,6 +266,14 @@ export function ReviewForm({ osmType, osmId, onClose, editReview }: ReviewFormPr
           });
           queryClient.refetchQueries({
             queryKey: ["mapky", "place", osmType, osmId],
+            type: "active",
+          });
+          queryClient.refetchQueries({
+            queryKey: ["mapky", "place-full", osmType, osmId],
+            type: "active",
+          });
+          queryClient.refetchQueries({
+            queryKey: ["mapky", "reviews", "user", publicKey],
             type: "active",
           });
         }

--- a/src/lib/api/hooks.ts
+++ b/src/lib/api/hooks.ts
@@ -263,13 +263,14 @@ function usePlaceFullSlice<T>(
   osmId: number,
   select: (data: PlaceFullResponse) => T,
 ) {
+  const queryKey = placeFullKey(osmType, osmId);
   return useQuery({
-    queryKey: placeFullKey(osmType, osmId),
+    queryKey,
     queryFn: () => fetchPlaceDetailFull(osmType, osmId),
     enabled: !!osmType && !!osmId,
     staleTime: PLACE_FULL_STALE_MS,
     retry: noRetryOn404,
-    select,
+    select: (data) => select(applyPending(queryKey, data)),
   });
 }
 

--- a/src/lib/api/mapky.ts
+++ b/src/lib/api/mapky.ts
@@ -267,6 +267,36 @@ export async function fetchPlaceTags(
   return data;
 }
 
+interface ResourceTagsResponse {
+  tags: Array<{
+    label: string;
+    taggers: string[];
+    taggers_count: number;
+  }>;
+}
+
+export async function fetchOsmResourceTags(
+  osmType: string,
+  osmId: number,
+): Promise<PostTagDetails[]> {
+  try {
+    const uri = `https://www.openstreetmap.org/${osmType}/${osmId}`;
+    const { data } = await nexusClient.get<ResourceTagsResponse>(
+      "/v0/resource/by-uri",
+      { params: { uri } },
+    );
+    return data.tags.map((tag) => ({
+      label: tag.label,
+      taggers: tag.taggers,
+      taggers_count: tag.taggers_count,
+    }));
+  } catch (err) {
+    const status = (err as { response?: { status?: number } }).response?.status;
+    if (status === 404) return [];
+    throw err;
+  }
+}
+
 export async function fetchPostTags(
   authorId: string,
   postId: string,


### PR DESCRIPTION
## Summary
- Apply pending optimistic overlays to the composite place-full cache used by place reviews and posts.
- Seed minimal place-full cache data so posts, reviews, and tags render immediately for not-yet-indexed places.
- Fall back to Nexus universal resource tags for OSM URLs when a MapKy Place node does not exist yet.

## Testing
- npm run build

Fixes #19